### PR TITLE
rename GdmlImportDetectorSteppingAction to EicRootSteppingAction

### DIFF
--- a/source/EicRootSteppingAction.cc
+++ b/source/EicRootSteppingAction.cc
@@ -41,7 +41,7 @@
 using namespace std;
 
 //____________________________________________________________________________..
-GdmlImportDetectorSteppingAction::GdmlImportDetectorSteppingAction(EicRootDetector *detector, const PHParameters *parameters)
+EicRootSteppingAction::EicRootSteppingAction(EicRootDetector *detector, const PHParameters *parameters)
   : PHG4SteppingAction(detector->GetName())
   , m_Detector(detector)
   , m_Params(parameters)
@@ -60,7 +60,7 @@ GdmlImportDetectorSteppingAction::GdmlImportDetectorSteppingAction(EicRootDetect
 }
 
 //____________________________________________________________________________..
-GdmlImportDetectorSteppingAction::~GdmlImportDetectorSteppingAction()
+EicRootSteppingAction::~EicRootSteppingAction()
 {
   // if the last hit was a zero energie deposit hit, it is just reset
   // and the memory is still allocated, so we need to delete it here
@@ -71,7 +71,7 @@ GdmlImportDetectorSteppingAction::~GdmlImportDetectorSteppingAction()
 
 //____________________________________________________________________________..
 // This is the implementation of the G4 UserSteppingAction
-bool GdmlImportDetectorSteppingAction::UserSteppingAction(const G4Step *aStep, bool was_used)
+bool EicRootSteppingAction::UserSteppingAction(const G4Step *aStep, bool was_used)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();

--- a/source/EicRootSteppingAction.h
+++ b/source/EicRootSteppingAction.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef GDMLIMPORTDETECTORSTEPPINGACTION_H
-#define GDMLIMPORTDETECTORSTEPPINGACTION_H
+#ifndef EICROOTSTEPPINGACTION_H
+#define EICROOTSTEPPINGACTION_H
 
 #include <g4main/PHG4SteppingAction.h>
 
@@ -14,14 +14,14 @@ class PHG4Hit;
 class PHG4HitContainer;
 class PHParameters;
 
-class GdmlImportDetectorSteppingAction : public PHG4SteppingAction
+class EicRootSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  GdmlImportDetectorSteppingAction(EicRootDetector *, const PHParameters* parameters);
+  EicRootSteppingAction(EicRootDetector *, const PHParameters* parameters);
 
   //! destructor
-  virtual ~GdmlImportDetectorSteppingAction();
+  virtual ~EicRootSteppingAction();
 
   //! stepping action
   virtual bool UserSteppingAction(const G4Step*, bool);
@@ -45,4 +45,4 @@ class GdmlImportDetectorSteppingAction : public PHG4SteppingAction
   double m_EdepSum;
 };
 
-#endif  // GDMLIMPORTDETECTORSTEPPINGACTION_H
+#endif  // EICROOTSTEPPINGACTION_H

--- a/source/EicRootSubsystem.cc
+++ b/source/EicRootSubsystem.cc
@@ -68,7 +68,7 @@ int EicRootSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 
     m_Detector->set_hitcontainer(new PHG4HitContainer(GetG4HitName()));
     DetNode->addNode(new PHIODataNode<PHObject>(m_Detector->get_hitcontainer(), GetG4HitName(), "PHObject"));
-    m_SteppingAction = new GdmlImportDetectorSteppingAction(m_Detector, GetParams());
+    m_SteppingAction = new EicRootSteppingAction(m_Detector, GetParams());
   } //if
 
   return 0;


### PR DESCRIPTION
This PR fixes the crash caused by just loading the library together with the fun4allgdmlimport. The reason was a misnamed stepping action which duplicated the one from fun4allgdmlimport